### PR TITLE
feat: add service card selection

### DIFF
--- a/components/booking/ServiceCard.tsx
+++ b/components/booking/ServiceCard.tsx
@@ -1,0 +1,47 @@
+import { Card } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+export type ServiceType = "INTERIEUR" | "EXTERIEUR" | "POLISH" | "MAISON";
+
+interface ServiceCardProps {
+  id: string;
+  title: string;
+  price: number;
+  durationMin: number;
+  type: ServiceType;
+  selected: boolean;
+  onSelect: () => void;
+}
+
+function formatDuration(min: number) {
+  const hours = Math.floor(min / 60);
+  const minutes = min % 60;
+  if (hours && minutes) {
+    return `${hours} h ${minutes} min`;
+  }
+  if (hours) {
+    return `${hours} h`;
+  }
+  return `${minutes} min`;
+}
+
+export function ServiceCard({ title, price, durationMin, selected, onSelect }: ServiceCardProps) {
+  return (
+    <Card
+      onClick={onSelect}
+      className={cn(
+        "p-4 cursor-pointer bg-white/5 border border-white/10 hover:bg-white/10 transition-colors",
+        selected && "border-[#D4AF37]"
+      )}
+    >
+      <div className="flex justify-between items-start mb-2">
+        <h3 className="text-white font-medium">{title}</h3>
+        <span className="text-[#D4AF37] font-semibold">{price} €</span>
+      </div>
+      <div className="text-right text-white/70 text-sm">{formatDuration(durationMin)}</div>
+    </Card>
+  );
+}
+
+export default ServiceCard;
+

--- a/lib/business-logic.ts
+++ b/lib/business-logic.ts
@@ -1,3 +1,6 @@
+export type PlaceType = 'PRIVE' | 'PUBLIC' | 'HUB'
+export type Gearbox = 'BVA' | 'BVM'
+
 export interface BookingFormData {
   customerName: string
   customerEmail: string
@@ -6,8 +9,8 @@ export interface BookingFormData {
   postalCode: string
   city: string
   vehicleType: string
-  gearbox: 'BVA' | 'BVM'
-  placeType: 'PRIVE' | 'PUBLIC' | 'HUB'
+  gearbox: Gearbox
+  placeType: PlaceType
   serviceType: string
   convoyageDistance?: '0_10' | '11_20'
   date: string
@@ -26,7 +29,7 @@ export const ZONE_MAPPING: Record<string, number> = {
 // Zone schedule (which days exterior services are available)
 export const ZONE_SCHEDULE: Record<number, number[]> = {
   1: [1], // Zone 1 (93) - Monday only
-  2: [4], // Zone 2 (92) - Thursday only  
+  2: [4], // Zone 2 (92) - Thursday only
   3: [5], // Zone 3 (91) - Friday only
   4: [3], // Zone 4 (77) - Wednesday only
 }
@@ -36,13 +39,14 @@ export const CONVOYAGE_PRICES = {
   '11_20': 39, // 11-20 km
 }
 
-export const SERVICE_PRICES = {
-  INTERIEUR_PREMIUM: 100,
-  EXTERIEUR_INTERIEUR_COMPLET: 220,
-  SOFT_POLISH_SEALANT: 240,
-  VTC_ZEN_45: 35,
-  CANAPE_3_PLACES: 100,
-}
+export const SERVICES = [
+  { id: 'interieur', title: 'Intérieur Premium', price: 100, durationMin: 75, type: 'INTERIEUR' },
+  { id: 'complet', title: 'Extérieur + Intérieur (Complet)', price: 220, durationMin: 120, type: 'EXTERIEUR' },
+  { id: 'polish', title: 'Soft Polish + Sealant', price: 240, durationMin: 210, type: 'POLISH' },
+  { id: 'maison', title: 'Canapé 3 places', price: 100, durationMin: 60, type: 'MAISON' }
+] as const;
+
+export const isExterior = (serviceId: string) => ['complet', 'polish'].includes(serviceId);
 
 export function validateBookingRules(data: BookingFormData): {
   isValid: boolean
@@ -54,14 +58,14 @@ export function validateBookingRules(data: BookingFormData): {
 
   // Rule 1: Public location restrictions
   if (data.placeType === 'PUBLIC') {
-    if (data.serviceType !== 'INTERIEUR_PREMIUM') {
+    if (data.serviceType !== 'interieur') {
       errors.push('Les services extérieurs ne sont pas disponibles sur voie publique')
       suggestions.push('Nous vous proposons le service "Intérieur Premium" uniquement')
     }
   }
 
   // Rule 2: Exterior services require private or hub location
-  if (['EXTERIEUR_INTERIEUR_COMPLET', 'SOFT_POLISH_SEALANT'].includes(data.serviceType)) {
+  if (isExterior(data.serviceType)) {
     if (data.placeType === 'PUBLIC') {
       errors.push('Ce service nécessite un emplacement privé ou notre micro-hub')
       suggestions.push('Veuillez sélectionner "Emplacement privé" ou "Micro-hub AS"')
@@ -75,7 +79,7 @@ export function validateBookingRules(data: BookingFormData): {
   }
 
   // Rule 4: Zone-based scheduling for exterior services
-  if (['EXTERIEUR_INTERIEUR_COMPLET', 'SOFT_POLISH_SEALANT'].includes(data.serviceType)) {
+  if (isExterior(data.serviceType)) {
     const zone = getZoneFromPostalCode(data.postalCode)
     if (zone) {
       const allowedDays = ZONE_SCHEDULE[zone]
@@ -104,25 +108,8 @@ export function getZoneFromPostalCode(postalCode: string): number | null {
 }
 
 export function calculateTotalPrice(data: BookingFormData): number {
-  let basePrice = 0
-
-  switch (data.serviceType) {
-    case 'INTERIEUR_PREMIUM':
-      basePrice = SERVICE_PRICES.INTERIEUR_PREMIUM
-      break
-    case 'EXTERIEUR_INTERIEUR_COMPLET':
-      basePrice = SERVICE_PRICES.EXTERIEUR_INTERIEUR_COMPLET
-      break
-    case 'SOFT_POLISH_SEALANT':
-      basePrice = SERVICE_PRICES.SOFT_POLISH_SEALANT
-      break
-    case 'VTC_ZEN_45':
-      basePrice = SERVICE_PRICES.VTC_ZEN_45
-      break
-    case 'CANAPE_3_PLACES':
-      basePrice = SERVICE_PRICES.CANAPE_3_PLACES
-      break
-  }
+  const service = SERVICES.find(s => s.id === data.serviceType)
+  let basePrice = service ? service.price : 0
 
   // Add convoyage price if applicable
   if (data.convoyageDistance && data.gearbox === 'BVA') {

--- a/lib/i18n/locales/fr.json
+++ b/lib/i18n/locales/fr.json
@@ -57,11 +57,10 @@
     "balance": "Solde à régler sur place"
   },
   "services": {
-    "interior_premium": "Intérieur Premium",
-    "complete": "Extérieur + Intérieur Complet", 
-    "polish_sealant": "Soft Polish + Sealant",
-    "vtc_zen": "VTC Zen 45min",
-    "sofa_cleaning": "Canapé 3 places"
+    "interieur": "Intérieur Premium",
+    "complet": "Extérieur + Intérieur (Complet)",
+    "polish": "Soft Polish + Sealant",
+    "maison": "Canapé 3 places"
   },
   "validation": {
     "required_field": "Ce champ est obligatoire",


### PR DESCRIPTION
## Summary
- add ServiceCard component for booking options
- centralize service definitions and pricing in business logic
- switch reservation page to card-based service selection and update API usage

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: multiple react/no-unescaped-entities errors)
- `npm run build` (fails: Module not found: Can't resolve 'next-auth/react')

------
https://chatgpt.com/codex/tasks/task_e_68b1cb29cc008325a2565f30de2f4c13