### PR TITLE
feat: add client portal and subscription management

### DIFF
--- a/app/actions/account.ts
+++ b/app/actions/account.ts
@@ -1,0 +1,98 @@
+'use server'
+
+import { z } from 'zod'
+import { prisma } from '@/lib/prisma'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { differenceInHours } from 'date-fns'
+import { ZONE_SCHEDULE, getZoneFromPostalCode, isExterior } from '@/lib/business-logic'
+
+const profileSchema = z.object({
+  name: z.string().min(1).optional(),
+  phone: z.string().optional(),
+  defaultAddress: z.string().optional(),
+})
+
+export async function updateProfile(data: {
+  name?: string
+  phone?: string
+  defaultAddress?: string
+}) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user) {
+    throw new Error('Non authentifié')
+  }
+
+  const parsed = profileSchema.parse(data)
+
+  await prisma.customer.updateMany({
+    where: { userId: session.user.id },
+    data: parsed,
+  })
+  return { success: true }
+}
+
+const rescheduleSchema = z.object({
+  bookingId: z.string(),
+  newDate: z.string(),
+  newTime: z.string(),
+})
+
+export async function requestReschedule(input: {
+  bookingId: string
+  newDate: string
+  newTime: string
+}) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user) {
+    throw new Error('Non authentifié')
+  }
+
+  const { bookingId, newDate, newTime } = rescheduleSchema.parse(input)
+  const booking = await prisma.booking.findUnique({
+    where: { id: bookingId },
+    include: { service: true, customer: true },
+  })
+  if (!booking || booking.customer.userId !== session.user.id) {
+    throw new Error('Accès refusé')
+  }
+
+  if (booking.rescheduleCount >= booking.rescheduleLimit) {
+    throw new Error('Replanification déjà utilisée')
+  }
+
+  if (differenceInHours(booking.date, new Date()) < 24) {
+    throw new Error('Trop tard pour replanifier')
+  }
+
+  const newDateTime = new Date(`${newDate}T${newTime}:00`)
+  const zone = getZoneFromPostalCode(booking.postalCode)
+
+  if (booking.service && isExterior(booking.service.name.toLowerCase())) {
+    if (booking.placeType === 'PUBLIC') {
+      throw new Error('Ce service nécessite un lieu privé ou micro-hub')
+    }
+    if (zone) {
+      const allowed = ZONE_SCHEDULE[zone]
+      if (!allowed.includes(newDateTime.getDay())) {
+        throw new Error('Jour non disponible pour votre zone')
+      }
+    }
+  }
+
+  if (booking.gearbox === 'BVM' && booking.convoyageKmBand) {
+    throw new Error('Convoyage indisponible pour boîte manuelle')
+  }
+
+  await prisma.booking.update({
+    where: { id: bookingId },
+    data: {
+      date: newDateTime,
+      startTime: newTime,
+      zone: zone,
+      rescheduleCount: { increment: 1 },
+    },
+  })
+
+  return { success: true }
+}

--- a/app/actions/subscription.ts
+++ b/app/actions/subscription.ts
@@ -1,0 +1,46 @@
+'use server'
+
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import { stripe } from '@/lib/stripe'
+
+export async function openPortal() {
+  const session = await getServerSession(authOptions)
+  if (!session?.user) {
+    throw new Error('Non authentifié')
+  }
+
+  const customer = await prisma.customer.findFirst({ where: { userId: session.user.id } })
+  if (!customer?.stripeCustomerId) {
+    throw new Error('Client Stripe introuvable')
+  }
+
+  const portal = await stripe.billingPortal.sessions.create({
+    customer: customer.stripeCustomerId,
+    return_url: `${process.env.NEXTAUTH_URL || 'http://localhost:3000'}/espace-client`,
+  })
+
+  return { url: portal.url }
+}
+
+export async function cancelAtPeriodEnd() {
+  const session = await getServerSession(authOptions)
+  if (!session?.user) {
+    throw new Error('Non authentifié')
+  }
+
+  const subscription = await prisma.subscription.findFirst({
+    where: { customer: { userId: session.user.id }, status: 'ACTIVE' },
+  })
+  if (!subscription) {
+    throw new Error('Aucun abonnement actif')
+  }
+
+  await stripe.subscriptions.update(subscription.stripeSubId, {
+    cancel_at_period_end: true,
+  })
+
+  // DB will be updated via webhook
+  return { success: true }
+}

--- a/app/espace-client/page.tsx
+++ b/app/espace-client/page.tsx
@@ -1,0 +1,62 @@
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { prisma } from '@/lib/prisma'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import ProfileForm from './profile-form'
+import SubscriptionSection from './subscription-section'
+
+export default async function EspaceClientPage() {
+  const session = await getServerSession(authOptions)
+  if (!session?.user) {
+    redirect('/auth/signin')
+  }
+
+  const customer = await prisma.customer.findFirst({
+    where: { userId: session.user.id },
+    include: {
+      bookings: {
+        orderBy: { date: 'asc' },
+      },
+      subscriptions: true,
+    },
+  })
+
+  return (
+    <div className="max-w-5xl mx-auto py-8 text-white">
+      <Tabs defaultValue="dashboard">
+        <TabsList className="mb-4">
+          <TabsTrigger value="dashboard">Tableau de bord</TabsTrigger>
+          <TabsTrigger value="bookings">Mes réservations</TabsTrigger>
+          <TabsTrigger value="profile">Profil</TabsTrigger>
+          <TabsTrigger value="subscription">Abonnement</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="dashboard">
+          <h2 className="text-2xl mb-4">Bienvenue {customer?.name}</h2>
+          <p>Vous avez {customer?.bookings.length || 0} réservation(s).</p>
+        </TabsContent>
+
+        <TabsContent value="bookings">
+          {customer?.bookings.map((b) => (
+            <div key={b.id} className="border-b border-white/10 py-2">
+              <p>{b.serviceId} - {new Date(b.date).toLocaleString('fr-FR')}</p>
+            </div>
+          ))}
+        </TabsContent>
+
+        <TabsContent value="profile">
+          <ProfileForm customer={customer} />
+        </TabsContent>
+
+        <TabsContent value="subscription">
+          {customer?.subscriptions[0] ? (
+            <SubscriptionSection subscription={customer.subscriptions[0]} />
+          ) : (
+            <p>Aucun abonnement actif.</p>
+          )}
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/app/espace-client/profile-form.tsx
+++ b/app/espace-client/profile-form.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useTransition } from 'react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { updateProfile } from '../actions/account'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { toast } from 'sonner'
+
+const schema = z.object({
+  name: z.string().min(1, 'Nom requis'),
+  phone: z.string().optional(),
+  defaultAddress: z.string().optional(),
+})
+
+export default function ProfileForm({ customer }: { customer: any }) {
+  const [pending, startTransition] = useTransition()
+  const form = useForm<z.infer<typeof schema>>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      name: customer?.name || '',
+      phone: customer?.phone || '',
+      defaultAddress: customer?.defaultAddress || '',
+    },
+  })
+
+  const onSubmit = (values: z.infer<typeof schema>) => {
+    startTransition(async () => {
+      try {
+        await updateProfile(values)
+        toast.success('Profil mis à jour')
+      } catch (e: any) {
+        toast.error(e.message)
+      }
+    })
+  }
+
+  return (
+    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 max-w-md">
+      <Input placeholder="Nom" {...form.register('name')} />
+      <Input placeholder="Téléphone" {...form.register('phone')} />
+      <Input placeholder="Adresse par défaut" {...form.register('defaultAddress')} />
+      <Button type="submit" disabled={pending}>
+        Enregistrer
+      </Button>
+    </form>
+  )
+}

--- a/app/espace-client/subscription-section.tsx
+++ b/app/espace-client/subscription-section.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useTransition } from 'react'
+import { Button } from '@/components/ui/button'
+import { openPortal, cancelAtPeriodEnd } from '../actions/subscription'
+
+export default function SubscriptionSection({ subscription }: { subscription: any }) {
+  const [pending, startTransition] = useTransition()
+
+  const manage = () => {
+    startTransition(async () => {
+      const res = await openPortal()
+      if (res.url) {
+        window.location.href = res.url
+      }
+    })
+  }
+
+  const cancel = () => {
+    startTransition(async () => {
+      await cancelAtPeriodEnd()
+    })
+  }
+
+  return (
+    <div className="space-y-4">
+      <p>Plan: {subscription.plan}</p>
+      <p>Statut: {subscription.status}</p>
+      <p>Renouvellement: {new Date(subscription.currentPeriodEnd).toLocaleDateString('fr-FR')}</p>
+      <Button onClick={manage} disabled={pending}>Gérer dans Stripe</Button>
+      <Button onClick={cancel} variant="destructive" disabled={pending}>
+        Résilier fin de période
+      </Button>
+    </div>
+  )
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
+  experimental: {
+    serverActions: true,
+  },
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/prisma/migrations/20240919000000_client_portal/migration.sql
+++ b/prisma/migrations/20240919000000_client_portal/migration.sql
@@ -1,0 +1,43 @@
+-- Migration for client portal features
+-- This migration adds profile fields, reschedule counters and simplifies subscription status.
+
+CREATE TABLE "_Customer_new" (
+    "id" TEXT PRIMARY KEY NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "phone" TEXT,
+    "userId" TEXT,
+    "defaultAddress" TEXT,
+    "stripeCustomerId" TEXT,
+    "createdAt" DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "updatedAt" DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT "Customer_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "_Customer_new" ("id","name","email","phone","userId","createdAt","updatedAt")
+  SELECT "id","name","email","phone","userId","createdAt","updatedAt" FROM "Customer";
+DROP TABLE "Customer";
+ALTER TABLE "_Customer_new" RENAME TO "Customer";
+CREATE UNIQUE INDEX "Customer_email_key" ON "Customer"("email");
+CREATE UNIQUE INDEX "Customer_stripeCustomerId_key" ON "Customer"("stripeCustomerId");
+
+ALTER TABLE "Booking" ADD COLUMN "rescheduleCount" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "Booking" ADD COLUMN "rescheduleLimit" INTEGER NOT NULL DEFAULT 1;
+
+-- Subscription status enum updated to ACTIVE/PAUSED/CANCELED.
+-- currentPeriodStart column removed.
+CREATE TABLE "_Subscription_new" (
+    "id" TEXT PRIMARY KEY NOT NULL,
+    "customerId" TEXT NOT NULL,
+    "stripeSubId" TEXT NOT NULL,
+    "plan" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'ACTIVE',
+    "currentPeriodEnd" DATETIME NOT NULL,
+    "createdAt" DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "updatedAt" DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT "Subscription_customerId_fkey" FOREIGN KEY ("customerId") REFERENCES "Customer"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "_Subscription_new" ("id","customerId","stripeSubId","plan","status","currentPeriodEnd","createdAt","updatedAt")
+  SELECT "id","customerId","stripeSubId","plan","status","currentPeriodEnd","createdAt","updatedAt" FROM "Subscription";
+DROP TABLE "Subscription";
+ALTER TABLE "_Subscription_new" RENAME TO "Subscription";
+CREATE UNIQUE INDEX "Subscription_stripeSubId_key" ON "Subscription"("stripeSubId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,9 +69,11 @@ model Customer {
   id            String        @id @default(cuid())
   name          String
   email         String        @unique
-  phone         String
+  phone         String?
   user          User?         @relation(fields: [userId], references: [id])
   userId        String?
+  defaultAddress String?
+  stripeCustomerId String? @unique
   bookings      Booking[]
   subscriptions Subscription[]
   reviews       Review[]
@@ -126,6 +128,8 @@ model Booking {
   stripeDepositId   String?
   stripePaymentId   String?
   notes             String?
+  rescheduleCount   Int            @default(0)
+  rescheduleLimit   Int            @default(1)
   
   createdAt         DateTime       @default(now())
   updatedAt         DateTime       @updatedAt
@@ -162,7 +166,6 @@ model Subscription {
   stripeSubId     String             @unique
   plan            SubscriptionPlan
   status          SubscriptionStatus
-  currentPeriodStart DateTime
   currentPeriodEnd   DateTime
   
   createdAt       DateTime           @default(now())
@@ -177,9 +180,8 @@ enum SubscriptionPlan {
 
 enum SubscriptionStatus {
   ACTIVE
-  CANCELLED
-  PAST_DUE
-  UNPAID
+  PAUSED
+  CANCELED
 }
 
 model Review {


### PR DESCRIPTION
## Summary
- add authenticated client portal with dashboard, bookings, profile and subscription tabs
- implement profile updates, rescheduling rules and Stripe subscription helpers
- extend Prisma schema for customer profile, rescheduling and subscription status

## Testing
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 DATABASE_URL="file:./dev.db" npx prisma migrate dev --name client-portal` *(fails: Failed to fetch the engine file - 403 Forbidden)*
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 DATABASE_URL="file:./dev.db" npx prisma generate` *(fails: Failed to fetch the engine file - 403 Forbidden)*
- `npm run lint` *(fails: numerous react/no-unescaped-entities errors in existing files)*
- `npm run build` *(fails: missing next-auth package and server actions not enabled previously)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cfabfb188325ac2290f32eeb3602