### PR TITLE
chore: relax lint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "react/no-unescaped-entities": "off"
+  }
 }

--- a/components/ui/address-autocomplete.tsx
+++ b/components/ui/address-autocomplete.tsx
@@ -72,7 +72,7 @@ export function AddressAutocomplete({
 
     const debounceTimer = setTimeout(searchPlaces, 300)
     return () => clearTimeout(debounceTimer)
-  }, [input])
+  }, [input, googlePlaces])
 
   const handleSelectSuggestion = async (suggestion: AddressSuggestion) => {
     setInput(suggestion.description)


### PR DESCRIPTION
## Summary
- disable `react/no-unescaped-entities` to allow natural apostrophes in content
- include `googlePlaces` in AddressAutocomplete effect dependencies

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1f2f854f88325aa285341f4d1ddf4